### PR TITLE
Added feature - Default order option

### DIFF
--- a/DatatableJS/Builders/GridBuilder.cs
+++ b/DatatableJS/Builders/GridBuilder.cs
@@ -28,7 +28,7 @@ namespace DatatableJS
 
         internal List<ColumnDefinition> _columns = new List<ColumnDefinition>();
         internal List<FilterModel> _filters = new List<FilterModel>();
-        internal List<OrderModel> _defaultOrders = new List<OrderModel>();
+        internal List<OrderModel> _orders = new List<OrderModel>();
 
         /// <summary>
         /// Default name is "DataGrid".
@@ -100,15 +100,18 @@ namespace DatatableJS
         }
 
         /// <summary>
-        /// Enable ordering and set default.
+        /// Enable ordering and set default order.
         /// </summary>
         /// <param name="config"></param>
         /// <returns></returns>
-        public GridBuilder<T> Ordering(Action<OrderBuilder<T>> config)
+        public GridBuilder<T> Order(Action<OrderBuilder<T>> config)
         {
+            if (!_ordering)
+            {
+                _ordering = true;
+            }
             var builder = new OrderBuilder<T>(this);
             config(builder);
-            _ordering = true;
             return this;
         }
 

--- a/DatatableJS/Builders/GridBuilder.cs
+++ b/DatatableJS/Builders/GridBuilder.cs
@@ -28,6 +28,7 @@ namespace DatatableJS
 
         internal List<ColumnDefinition> _columns = new List<ColumnDefinition>();
         internal List<FilterModel> _filters = new List<FilterModel>();
+        internal List<OrderModel> _defaultOrders = new List<OrderModel>();
 
         /// <summary>
         /// Default name is "DataGrid".
@@ -95,6 +96,19 @@ namespace DatatableJS
         public GridBuilder<T> Ordering(bool ordering)
         {
             _ordering = ordering;
+            return this;
+        }
+
+        /// <summary>
+        /// Enable ordering and set default.
+        /// </summary>
+        /// <param name="config"></param>
+        /// <returns></returns>
+        public GridBuilder<T> Ordering(Action<OrderBuilder<T>> config)
+        {
+            var builder = new OrderBuilder<T>(this);
+            config(builder);
+            _ordering = true;
             return this;
         }
 

--- a/DatatableJS/Builders/OrderBuilder.cs
+++ b/DatatableJS/Builders/OrderBuilder.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Linq.Expressions;
+
+namespace DatatableJS
+{
+    /// <summary>
+    /// Generic order builder class.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class OrderBuilder<T>
+    {
+        private readonly GridBuilder<T> _grid;
+        private OrderModel _order { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrderBuilder{T}"/> class.
+        /// </summary>
+        /// <param name="grid">The grid.</param>
+        public OrderBuilder(GridBuilder<T> grid)
+        {
+            _grid = grid;
+        }
+
+        /// <summary>
+        /// Adds the specified column for default ordering.
+        /// </summary>
+        /// <param name="column">The column number.</param>
+        /// <param name="order">The order.</param>
+        /// <returns></returns>
+        public OrderBuilder<T> Add(int column, Order order)
+        {
+            _order = new OrderModel
+            {
+                Column = column,
+                Order = order
+            };
+            _grid._defaultOrders.Add(_order);
+
+            return this;
+        }
+    }
+}

--- a/DatatableJS/Builders/OrderBuilder.cs
+++ b/DatatableJS/Builders/OrderBuilder.cs
@@ -34,7 +34,7 @@ namespace DatatableJS
                 Column = column,
                 Order = order
             };
-            _grid._defaultOrders.Add(_order);
+            _grid._orders.Add(_order);
 
             return this;
         }

--- a/DatatableJS/JSHelper.cs
+++ b/DatatableJS/JSHelper.cs
@@ -78,6 +78,7 @@ namespace DatatableJS
                                         }});
                                     }},"
                                     : string.Empty;
+            
             var html = $@"
                     <table id=""{gridBuilder._name}"" class=""{gridBuilder._cssClass}"" style=""width:100%"">
                         <thead>
@@ -97,9 +98,7 @@ namespace DatatableJS
                                 lJStColumns: {gridBuilder._leftColumns},
                                 rightColumns: {gridBuilder._rightColumns}
                             }},
-                            order: [{(!gridBuilder._ordering ? string.Empty : string.Join(", ", gridBuilder._defaultOrders.Select(a => $@"
-                                [{a.Column}, '{(a.Order == Order.Ascending ? "asc" : "desc")}']
-                            ")))}],
+                            order: [{(!gridBuilder._ordering ? string.Empty : string.Join(", ", gridBuilder._orders.Select(a => $@"[{ a.Column}, '{(a.Order == Order.Ascending ? "asc" : "desc")}']")))}],
                             ordering: {gridBuilder._ordering.ToLowString()},
                             searching: {gridBuilder._searching.ToLowString()},
                             paging: {gridBuilder._paging.ToLowString()},

--- a/DatatableJS/JSHelper.cs
+++ b/DatatableJS/JSHelper.cs
@@ -97,7 +97,9 @@ namespace DatatableJS
                                 lJStColumns: {gridBuilder._leftColumns},
                                 rightColumns: {gridBuilder._rightColumns}
                             }},
-                            order:[],
+                            order: [{(!gridBuilder._ordering ? string.Empty : string.Join(", ", gridBuilder._defaultOrders.Select(a => $@"
+                                [{a.Column}, '{(a.Order == Order.Ascending ? "asc" : "desc")}']
+                            ")))}],
                             ordering: {gridBuilder._ordering.ToLowString()},
                             searching: {gridBuilder._searching.ToLowString()},
                             paging: {gridBuilder._paging.ToLowString()},

--- a/DatatableJS/Models/OrderModel.cs
+++ b/DatatableJS/Models/OrderModel.cs
@@ -1,0 +1,14 @@
+﻿namespace DatatableJS
+{
+    public class OrderModel
+    {
+        public int Column { get; set; }
+        public Order Order { get; set; }
+    }
+
+    public enum Order
+    {
+        Ascending,
+        Descending
+    }
+}


### PR DESCRIPTION
Good afternoon,

I have been integrating your fantastic and useful library into my new net core project, and I have found that the **default order could not be specified**.

I **have made** the **necessary adjustments** to **allow it**.

### Changes made:
**How `.Order(Action<OrderBuilder<T>> config)` works:**
- If the method is not used, then no change is made.
- If used, then it retains the same functionality as the DataTables plugin: uses the **specified order** as the **default order applied to the table**. 

### Usage example:
```
.Order(defaultOrder => {
    defaultOrder.Add(0, Order.Ascending);
})
```
It uses the order specified by default, in our case it sort by the first column in ascending order. 

```
.Order(defaultOrder => {
    defaultOrder.Add(0, Order.Descending);
    defaultOrder.Add(1, Order.Ascending);
})
```
It uses the order specified by default, in our case, it first sort by the first column in descending order, and then sort by the second column in ascending order. 

### DataTables reference documentation used:
[https://datatables.net/reference/option/order](https://datatables.net/reference/option/order)

Check it out!

Best regards, Rodrigo 