### PR TITLE
Added feature - Default order using property

### DIFF
--- a/DatatableJS.Net/Definitions/OrderDefinition.cs
+++ b/DatatableJS.Net/Definitions/OrderDefinition.cs
@@ -3,6 +3,7 @@
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     public class OrderDefinition
     {
+        public string Field { get; set; }
         public int Column { get; set; }
         public Order Order { get; set; }
     }

--- a/DatatableJS.Net/Exceptions/ColumnNotFoundException.cs
+++ b/DatatableJS.Net/Exceptions/ColumnNotFoundException.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace DatatableJS.Net.Exceptions
+{
+    /// <summary>
+    /// Exception thrown when a column is not found.
+    /// </summary>
+    public class ColumnNotFoundException : Exception
+    {
+        /// <summary>
+        /// Create a new exception of type ColumnNotFoundException.
+        /// </summary>
+        public ColumnNotFoundException()
+        {
+        }
+
+        /// <summary>
+        /// Create a new exception of type ColumnNotFoundException.
+        /// </summary>
+        /// <param name="message"></param>
+        public ColumnNotFoundException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Create a new exception of type ColumnNotFoundException.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="inner"></param>
+        public ColumnNotFoundException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+    }
+}

--- a/DatatableJS/Builders/OrderBuilder.cs
+++ b/DatatableJS/Builders/OrderBuilder.cs
@@ -32,7 +32,7 @@ namespace DatatableJS
         /// <returns></returns>
         public OrderBuilder<T> Add<TProp>(Expression<Func<T, TProp>> property, Order order)
         {
-            var propertyName = PropertyName(property);
+            var propertyName = ExpressionHelpers<T>.PropertyName(property);
 
             var column = _grid._columns
                 .Where(c => c.Data.Equals(propertyName))
@@ -54,18 +54,6 @@ namespace DatatableJS
             _grid._orders.Add(_order);
 
             return this;
-        }
-
-        private static string PropertyName<TProp>(Expression<Func<T, TProp>> expression)
-        {
-            var body = expression.Body as MemberExpression;
-
-            if (body == null)
-            {
-                body = ((UnaryExpression) expression.Body).Operand as MemberExpression;
-            }
-
-            return body.Member.Name;
         }
     }
 }

--- a/DatatableJS/Builders/OrderBuilder.cs
+++ b/DatatableJS/Builders/OrderBuilder.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using DatatableJS.Exceptions;
+using System;
+using System.Linq;
 using System.Linq.Expressions;
 
 namespace DatatableJS
@@ -22,21 +24,48 @@ namespace DatatableJS
         }
 
         /// <summary>
-        /// Adds the specified column for default ordering.
+        /// Adds the specified property for default ordering.
         /// </summary>
-        /// <param name="column">The column number.</param>
+        /// <typeparam name="TProp">The type of the property.</typeparam>
+        /// <param name="property">The property.</param>
         /// <param name="order">The order.</param>
         /// <returns></returns>
-        public OrderBuilder<T> Add(int column, Order order)
+        public OrderBuilder<T> Add<TProp>(Expression<Func<T, TProp>> property, Order order)
         {
+            var propertyName = PropertyName(property);
+
+            var column = _grid._columns
+                .Where(c => c.Data.Equals(propertyName))
+                .FirstOrDefault();
+
+            if (column == null)
+            {
+                throw new ColumnNotFoundException(string.Format("Column not found for property {0}", propertyName));
+            }
+
+            var columnIndex = _grid._columns.IndexOf(column);
+
             _order = new OrderModel
             {
-                Column = column,
+                Field = propertyName,
+                Column = columnIndex,
                 Order = order
             };
             _grid._orders.Add(_order);
 
             return this;
+        }
+
+        private static string PropertyName<TProp>(Expression<Func<T, TProp>> expression)
+        {
+            var body = expression.Body as MemberExpression;
+
+            if (body == null)
+            {
+                body = ((UnaryExpression) expression.Body).Operand as MemberExpression;
+            }
+
+            return body.Member.Name;
         }
     }
 }

--- a/DatatableJS/Exceptions/ColumnNotFoundException.cs
+++ b/DatatableJS/Exceptions/ColumnNotFoundException.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace DatatableJS.Exceptions
+{
+    /// <summary>
+    /// Exception thrown when a column is not found.
+    /// </summary>
+    public class ColumnNotFoundException : Exception
+    {
+        /// <summary>
+        /// Create a new exception of type ColumnNotFoundException.
+        /// </summary>
+        public ColumnNotFoundException()
+        {
+        }
+
+        /// <summary>
+        /// Create a new exception of type ColumnNotFoundException.
+        /// </summary>
+        /// <param name="message"></param>
+        public ColumnNotFoundException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Create a new exception of type ColumnNotFoundException.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="inner"></param>
+        public ColumnNotFoundException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+    }
+}

--- a/DatatableJS/Models/OrderModel.cs
+++ b/DatatableJS/Models/OrderModel.cs
@@ -2,6 +2,7 @@
 {
     public class OrderModel
     {
+        public string Field { get; set; }
         public int Column { get; set; }
         public Order Order { get; set; }
     }


### PR DESCRIPTION
Hi @ekondur,

Glad to hear contributions are helpful.

I **have modified** the **order feature** to **use** the **properties** of the columns instead of their indexes.

```
.Orders(defaultOrder => {
  defaultOrder.Add(post => post.ID, Order.Descending);
})
```

Furthermore, if the **property has not been specified** in the **columns**, an exception of type `ColumnNotFoundException` will be thrown indicating it.

I have also updated the .net framework project.

Best regards