### PR TITLE
Fixed issue with multiple column sorting

### DIFF
--- a/DatatableJS.Data.UnitTest/DataTests.cs
+++ b/DatatableJS.Data.UnitTest/DataTests.cs
@@ -40,12 +40,12 @@ namespace DatatableJS.Data.UnitTest
         [Test]
         public void ToDataResult_WhenSortingByNameAndAge()
         {
-            _request.order.Add(new Order()
+            _request.order.Add(new Order
             {
                 column = 0,
                 dir = "asc"
             });
-            _request.order.Add(new Order()
+            _request.order.Add(new Order
             {
                 column = 1,
                 dir = "asc"

--- a/DatatableJS.Data.UnitTest/DataTests.cs
+++ b/DatatableJS.Data.UnitTest/DataTests.cs
@@ -15,12 +15,14 @@ namespace DatatableJS.Data.UnitTest
         {
             _list = new List<Person>
             {
-                new Person { Name = "Jon" },
-                new Person { Name = "Arya" }
+                new Person { Name = "Jon", Age = 1},
+                new Person { Name = "Arya", Age = 1 },
+                new Person { Name = "Arya", Age = 2 }
             }.AsQueryable();
 
             var _columns = new List<Column> {
-                new Column {data = "Name", name = "Name", orderable = true, searchable = true, search = new Search()}
+                new Column {data = "Name", name = "Name", orderable = true, searchable = true, search = new Search()},
+                new Column {data = "Age", name = "Age", orderable = true, searchable = true, search = new Search()},
             };
 
             _request = new DataRequest { columns = _columns, draw = 1, length = 10 };
@@ -34,10 +36,32 @@ namespace DatatableJS.Data.UnitTest
 
             Assert.That(result.data.Count, Is.EqualTo(1));
         }
+
+        [Test]
+        public void ToDataResult_WhenSortingByNameAndAge()
+        {
+            _request.order.Add(new Order()
+            {
+                column = 0,
+                dir = "asc"
+            });
+            _request.order.Add(new Order()
+            {
+                column = 1,
+                dir = "asc"
+            });
+            var result = _list.ToDataResult(_request);
+
+            Assert.That(result.data[0].Name, Is.EqualTo("Arya"));
+            Assert.That(result.data[0].Age, Is.EqualTo(1));
+            Assert.That(result.data[1].Name, Is.EqualTo("Arya"));
+            Assert.That(result.data[1].Age, Is.EqualTo(2));
+        }
     }
 
     public class Person
     {
         public string Name { get; set; }
+        public int Age { get; set; }
     }
 }

--- a/DatatableJS.Data/DatatableExtensions.cs
+++ b/DatatableJS.Data/DatatableExtensions.cs
@@ -75,16 +75,15 @@ namespace DatatableJS.Data
                 }
                 else
                 {
-                    foreach (var item in request.order)
+                    query = request.order[0].dir != "asc"
+                        ? (IQueryable<T>)query.OrderByDescending<T>(request.columns[request.order[0].column].data)
+                        : (IQueryable<T>)query.OrderBy<T>(request.columns[request.order[0].column].data);
+
+                    for (var i = 1; i < request.order.Count(); i++)
                     {
-                        if (item.dir == "asc")
-                        {
-                            query = query.OrderBy(request.columns[item.column].data);
-                        }
-                        else
-                        {
-                            query = query.OrderByDescending(request.columns[item.column].data);
-                        }
+                        query = request.order[i].dir != "asc"
+                            ? (IQueryable<T>)query.ThenByDescending<T>(request.columns[request.order[i].column].data)
+                            : (IQueryable<T>)query.ThenBy<T>(request.columns[request.order[i].column].data);
                     }
                 }
 
@@ -109,14 +108,32 @@ namespace DatatableJS.Data
                 });
         }
 
-        private static IOrderedQueryable<T> OrderBy<T>(this IQueryable<T> query, string memberName)
+        private static IOrderedQueryable<T> OrderBy<T>(
+            this IQueryable<T> query,
+            string memberName)
         {
-            return OrderByCreate(query, memberName, "OrderBy");
+            return query.OrderByCreate<T>(memberName, nameof(OrderBy));
         }
 
-        private static IOrderedQueryable<T> OrderByDescending<T>(this IQueryable<T> query, string memberName)
+        private static IOrderedQueryable<T> ThenBy<T>(
+            this IQueryable<T> query,
+            string memberName)
         {
-            return OrderByCreate(query, memberName, "OrderByDescending");
+            return query.OrderByCreate<T>(memberName, nameof(ThenBy));
+        }
+
+        private static IOrderedQueryable<T> OrderByDescending<T>(
+            this IQueryable<T> query,
+            string memberName)
+        {
+            return query.OrderByCreate<T>(memberName, nameof(OrderByDescending));
+        }
+
+        private static IOrderedQueryable<T> ThenByDescending<T>(
+            this IQueryable<T> query,
+            string memberName)
+        {
+            return query.OrderByCreate<T>(memberName, nameof(ThenByDescending));
         }
 
         private static IOrderedQueryable<T> OrderByCreate<T>(this IQueryable<T> query, string memberName, string direction)


### PR DESCRIPTION
When sorting by multiple columns only the last sort was getting applied.
Added ThenBy and ThenByDescending to any sorted column past the first one.