### PR TITLE
Removing data null check in Template #95

### DIFF
--- a/DatatableJS.Net/JSHelper.cs
+++ b/DatatableJS.Net/JSHelper.cs
@@ -155,7 +155,7 @@ namespace DatatableJS.Net
                                 'className': '{a.ClassName}',
                                 'visible': {a.Visible.ToLowString()},
                                 'width': '{(a.Width > 0 ? $"{a.Width}%" : string.Empty)}',
-                                    {(string.IsNullOrEmpty(a.Render) ? string.Empty : $"'render': function(data, type, row, meta) {{ if (data == null) {{ return ''; }} else {{ return {a.Render}; }} }}")}
+                                    {(string.IsNullOrEmpty(a.Render) ? string.Empty : $"'render': function(data, type, row, meta) {{ return {a.Render}; }}")}
                             }}"))}]
                         }});
                     }});

--- a/DatatableJS/Helpers/RenderHelper.cs
+++ b/DatatableJS/Helpers/RenderHelper.cs
@@ -59,7 +59,7 @@ namespace DatatableJS
                                 'className': '{a.ClassName}',
                                 'visible': {a.Visible.ToLowString()},
                                 'width': '{a.Width}%',
-                                    {(string.IsNullOrEmpty(a.Render) ? string.Empty : $"'render': function(data, type, row, meta) {{ if (data == null) {{ return ''; }} else {{ return {a.Render}; }} }}")}
+                                    {(string.IsNullOrEmpty(a.Render) ? string.Empty : $"'render': function(data, type, row, meta) {{ return {a.Render}; }}")}
                             }}"))}]
                 }});
             }});

--- a/DatatableJS/JSHelper.cs
+++ b/DatatableJS/JSHelper.cs
@@ -140,7 +140,7 @@ namespace DatatableJS
                                 'className': '{a.ClassName}',
                                 'visible': {a.Visible.ToLowString()},
                                 'width': '{(a.Width > 0 ? $"{a.Width}%" : string.Empty)}',
-                                    {(string.IsNullOrEmpty(a.Render) ? string.Empty : $"'render': function(data, type, row, meta) {{ if (data == null) {{ return ''; }} else {{ return {a.Render}; }} }}")}
+                                    {(string.IsNullOrEmpty(a.Render) ? string.Empty : $"'render': function(data, type, row, meta) {{ return {a.Render}; }}")}
                             }}"))}]
                         }});
                     }});


### PR DESCRIPTION
changed:

{(string.IsNullOrEmpty(a.Render) ? string.Empty : $"'render': function(data, type, row, meta) {{ if (data == null) {{ return ''; }} else {{ return {a.Render}; }} }}")}

to :

{(string.IsNullOrEmpty(a.Render) ? string.Empty : $"'render': function(data, type, row, meta) {{ return {a.Render}; }}")}

in the following files:

DatatableJS -> JSHelper.cs
DatatableJS -> RenderHelper.cs
DatatableJS.Net -> JSHelper.cs