### PR TITLE
adding dom option as per https://datatables.net/reference/option/dom …

### DIFF
--- a/DatatableJS.Net/Builders/GridBuilder.cs
+++ b/DatatableJS.Net/Builders/GridBuilder.cs
@@ -32,6 +32,7 @@ namespace DatatableJS.Net
         internal bool _processing { get; private set; } = true;
         internal bool _scrollX { get; private set; }
         internal bool _stateSave { get; set; }
+        internal string _dom { get; set; }
 
         internal bool _selectEnable { get; private set; }
         internal SelectStyle _selectStyle { get; private set; }

--- a/DatatableJS.Net/JSHelper.cs
+++ b/DatatableJS.Net/JSHelper.cs
@@ -71,6 +71,25 @@ namespace DatatableJS.Net
         /// <returns></returns>
         public static MvcHtmlString Render<T>(this GridBuilder<T> grid)
         {
+            var html = RenderHtmlString(grid);
+            var script = RenderScriptString(grid);
+            return new MvcHtmlString(html+script);
+        }
+
+
+        public static MvcHtmlString RenderHtml<T>(this GridBuilder<T> grid)
+        {
+            
+            return new MvcHtmlString(RenderHtmlString(grid));
+        }
+        public static MvcHtmlString RenderScript<T>(this GridBuilder<T> grid)
+        {
+
+            return new MvcHtmlString(RenderScriptString(grid));
+        }
+
+        private static string RenderHtmlString<T>(this GridBuilder<T> grid)
+        {
             var tfoot = grid._columnSearching ?
                         $@"<tfoot>
                             <tr class=""filters"">
@@ -79,6 +98,27 @@ namespace DatatableJS.Net
                         </tfoot>"
                         : string.Empty;
 
+            var tfootInit = string.Empty;
+
+
+
+            var html = $@"
+                    <table id=""{grid._name}"" class=""{grid._cssClass}"" style=""width:100%"">
+                        <thead>
+                            <tr>
+                                {string.Join(Environment.NewLine, grid._columns.Select(a => string.Format("<th>{0}</th>", a.Title)))}
+                            </tr>
+                        </thead>
+                        {tfoot}
+                    </table>
+                 ";
+
+            return html;
+        }
+
+
+        private static string RenderScriptString<T>(this GridBuilder<T> grid)
+        {
             var tfootInit = string.Empty;
 
             var initFootSearch = grid._stateSave ?
@@ -170,15 +210,7 @@ namespace DatatableJS.Net
                     $"lengthMenu: {string.Format("[[{0}], [{1}]]", string.Join(", ", grid._lengthMenuValues), string.Join(", ", grid._lengthMenuDisplayedTexts.Select(a => string.Concat(@"""", a, @""""))))},"
                 ;
 
-            var html = $@"
-                    <table id=""{grid._name}"" class=""{grid._cssClass}"" style=""width:100%"">
-                        <thead>
-                            <tr>
-                                {string.Join(Environment.NewLine, grid._columns.Select(a => string.Format("<th>{0}</th>", a.Title)))}
-                            </tr>
-                        </thead>
-                        {tfoot}
-                    </table>
+            var script = $@"
                     <script>
                     $(document).ready(function () {{
                         $('#{grid._name}').DataTable( {{
@@ -193,24 +225,25 @@ namespace DatatableJS.Net
                                 leftColumns: {grid._leftColumns},
                                 rightColumns: {grid._rightColumns}
                             }},
-                            order: [{(!grid._ordering ? string.Empty : string.Join(", ", grid._orders.Select(a => $@"[{ a.Column}, '{(a.OrderBy == OrderBy.Ascending ? "asc" : "desc")}']")))}],
+                            order: [{(!grid._ordering ? string.Empty : string.Join(", ", grid._orders.Select(a => $@"[{a.Column}, '{(a.OrderBy == OrderBy.Ascending ? "asc" : "desc")}']")))}],
                             ordering: {grid._ordering.ToLowString()},
                             searching: {grid._searching.ToLowString()},
                             paging: {grid._paging.ToLowString()},
+                            {(!string.IsNullOrEmpty(grid._dom) ? $"dom: '{grid._dom}'," : string.Empty)}
                             {lengthMenu}
-                            {(!string.IsNullOrEmpty(grid._callBack.CreatedRow) ? $"createdRow: function (row, data, dataIndex, cells) {{ {grid._callBack.CreatedRow}(row, data, dataIndex, cells); }}," : string.Empty) }
-                            {(!string.IsNullOrEmpty(grid._callBack.DrawCallback) ? $"drawCallback: function (settings) {{ {grid._callBack.DrawCallback}(settings); }}," : string.Empty) }
-                            {(!string.IsNullOrEmpty(grid._callBack.FooterCallback) ? $"footerCallback: function (tfoot, data, start, end, display) {{ {grid._callBack.FooterCallback}(tfoot, data, start, end, display); }}," : string.Empty) }
-                            {(!string.IsNullOrEmpty(grid._callBack.FormatNumber) ? $"formatNumber: function (toFormat) {{ {grid._callBack.FormatNumber}(toFormat); }}," : string.Empty) }
-                            {(!string.IsNullOrEmpty(grid._callBack.HeaderCallback) ? $"headerCallback: function (thead, data, start, end, display) {{ {grid._callBack.HeaderCallback}(thead, data, start, end, display); }}," : string.Empty) }
-                            {(!string.IsNullOrEmpty(grid._callBack.InfoCallback) ? $"infoCallback: function (settings, start, end, max, total, pre) {{ {grid._callBack.InfoCallback}(settings, start, end, max, total, pre); }}," : string.Empty) }
-                            {(!string.IsNullOrEmpty(grid._callBack.PreDrawCallback) ? $"preDrawCallback: function (settings) {{ {grid._callBack.PreDrawCallback}(settings); }}," : string.Empty) }
-                            {(!string.IsNullOrEmpty(grid._callBack.RowCallback) ? $"rowCallback: function (row, data, displayNum, displayIndex, dataIndex) {{ {grid._callBack.RowCallback}(row, data, displayNum, displayIndex, dataIndex); }}," : string.Empty) }
-                            {(!string.IsNullOrEmpty(grid._callBack.StateLoadCallback) ? $"stateLoadCallback: function (settings, callback) {{ {grid._callBack.StateLoadCallback}(settings, callback); }}," : string.Empty) }
-                            {(!string.IsNullOrEmpty(grid._callBack.StateLoadParams) ? $"stateLoadParams: function (settings, data) {{ {grid._callBack.StateLoadParams}(settings, data); }}," : string.Empty) }
-                            {(!string.IsNullOrEmpty(grid._callBack.StateLoaded) ? $"stateLoaded: function (settings, data) {{ {grid._callBack.StateLoaded}(settings, data); }}," : string.Empty) }
-                            {(!string.IsNullOrEmpty(grid._callBack.StateSaveCallback) ? $"stateSaveCallback: function (settings, data) {{ {grid._callBack.StateSaveCallback}(settings, data); }}," : string.Empty) }
-                            {(!string.IsNullOrEmpty(grid._callBack.StateSaveParams) ? $"stateSaveParams: function (settings, data) {{ {grid._callBack.StateSaveParams}(settings, data); }}," : string.Empty) }
+                            {(!string.IsNullOrEmpty(grid._callBack.CreatedRow) ? $"createdRow: function (row, data, dataIndex, cells) {{ {grid._callBack.CreatedRow}(row, data, dataIndex, cells); }}," : string.Empty)}
+                            {(!string.IsNullOrEmpty(grid._callBack.DrawCallback) ? $"drawCallback: function (settings) {{ {grid._callBack.DrawCallback}(settings); }}," : string.Empty)}
+                            {(!string.IsNullOrEmpty(grid._callBack.FooterCallback) ? $"footerCallback: function (tfoot, data, start, end, display) {{ {grid._callBack.FooterCallback}(tfoot, data, start, end, display); }}," : string.Empty)}
+                            {(!string.IsNullOrEmpty(grid._callBack.FormatNumber) ? $"formatNumber: function (toFormat) {{ {grid._callBack.FormatNumber}(toFormat); }}," : string.Empty)}
+                            {(!string.IsNullOrEmpty(grid._callBack.HeaderCallback) ? $"headerCallback: function (thead, data, start, end, display) {{ {grid._callBack.HeaderCallback}(thead, data, start, end, display); }}," : string.Empty)}
+                            {(!string.IsNullOrEmpty(grid._callBack.InfoCallback) ? $"infoCallback: function (settings, start, end, max, total, pre) {{ {grid._callBack.InfoCallback}(settings, start, end, max, total, pre); }}," : string.Empty)}
+                            {(!string.IsNullOrEmpty(grid._callBack.PreDrawCallback) ? $"preDrawCallback: function (settings) {{ {grid._callBack.PreDrawCallback}(settings); }}," : string.Empty)}
+                            {(!string.IsNullOrEmpty(grid._callBack.RowCallback) ? $"rowCallback: function (row, data, displayNum, displayIndex, dataIndex) {{ {grid._callBack.RowCallback}(row, data, displayNum, displayIndex, dataIndex); }}," : string.Empty)}
+                            {(!string.IsNullOrEmpty(grid._callBack.StateLoadCallback) ? $"stateLoadCallback: function (settings, callback) {{ {grid._callBack.StateLoadCallback}(settings, callback); }}," : string.Empty)}
+                            {(!string.IsNullOrEmpty(grid._callBack.StateLoadParams) ? $"stateLoadParams: function (settings, data) {{ {grid._callBack.StateLoadParams}(settings, data); }}," : string.Empty)}
+                            {(!string.IsNullOrEmpty(grid._callBack.StateLoaded) ? $"stateLoaded: function (settings, data) {{ {grid._callBack.StateLoaded}(settings, data); }}," : string.Empty)}
+                            {(!string.IsNullOrEmpty(grid._callBack.StateSaveCallback) ? $"stateSaveCallback: function (settings, data) {{ {grid._callBack.StateSaveCallback}(settings, data); }}," : string.Empty)}
+                            {(!string.IsNullOrEmpty(grid._callBack.StateSaveParams) ? $"stateSaveParams: function (settings, data) {{ {grid._callBack.StateSaveParams}(settings, data); }}," : string.Empty)}
                             {(!grid._pageLength.HasValue ? string.Empty : $"pageLength: {grid._pageLength.Value},")}
                             language: {{
                                 url: '{grid._language.URL}',
@@ -259,7 +292,7 @@ namespace DatatableJS.Net
                     {(string.IsNullOrEmpty(grid._captionBottom) ? string.Empty : string.Format("$('#{0}').append('<caption style=\"caption-side:bottom\">{1}</caption>');", grid._name, grid._captionBottom))}
                     </script>";
 
-            return new MvcHtmlString(html);
+            return script;
         }
 
         private static string GetDataStr<T>(this GridBuilder<T> grid)
@@ -273,3 +306,4 @@ namespace DatatableJS.Net
         }
     }
 }
+

--- a/DatatableJS/Builders/GridBuilder.cs
+++ b/DatatableJS/Builders/GridBuilder.cs
@@ -1,6 +1,8 @@
-﻿using System;
+﻿using Microsoft.AspNetCore.Mvc.Rendering;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using static System.Net.WebRequestMethods;
 
 namespace DatatableJS
 {
@@ -32,12 +34,14 @@ namespace DatatableJS
         internal bool _processing { get; private set; } = true;
         internal bool _scrollX { get; private set; }
         internal bool _stateSave { get; set; }
+        internal string _dom { get; private set; }
 
         internal bool _selectEnable { get; private set; }
         internal SelectStyle _selectStyle { get; private set; }
         internal SelectItems _selectItems { get; private set; }
         internal bool _selectInfo { get; private set; }
         internal bool _selectToggleable { get; private set; }
+        public IHtmlHelper HtmlHelper { get; }
 
         internal List<ColumnDefinition> _columns = new List<ColumnDefinition>();
         internal List<FilterModel> _filters = new List<FilterModel>();
@@ -46,6 +50,11 @@ namespace DatatableJS
         internal CallbackModel _callBack = new CallbackModel();
         internal LanguageModel _language = new LanguageModel();
         internal ColReorderModel _colReorder = new ColReorderModel();
+
+        public GridBuilder(IHtmlHelper htmlHelper)
+        {
+            HtmlHelper = htmlHelper;
+        }
 
         /// <summary>
         /// Default name is "DataGrid".
@@ -230,6 +239,19 @@ namespace DatatableJS
         public GridBuilder<T> Data(string data)
         {
             _data = data;
+            return this;
+        }
+
+
+        /// <summary>
+        /// Dom allow to control position of datatable elements
+        /// </summary>
+        /// <see cref="https://datatables.net/reference/option/dom"/>
+        /// <param name="dom"></param>
+        /// <returns></returns>
+        public GridBuilder<T> Dom(string dom)
+        {
+            _dom = dom; 
             return this;
         }
 

--- a/DatatableJS/Helpers/GridHelper.cs
+++ b/DatatableJS/Helpers/GridHelper.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+using static System.Net.WebRequestMethods;
 
 namespace DatatableJS
 {
@@ -39,6 +40,12 @@ namespace DatatableJS
         public bool StateSave { get; set; }
 
         /// <summary>
+        /// Enable control over displayed elements 
+        /// </summary>
+        /// <see cref="https://datatables.net/reference/option/dom"/>
+        public string Dom { get; set; }
+
+        /// <summary>
         /// Process
         /// </summary>
         /// <param name="context"></param>
@@ -58,7 +65,8 @@ namespace DatatableJS
                 Searching = Searching,
                 Processing = Processing,
                 ScrollX = ScrollX,
-                StateSave = StateSave
+                StateSave = StateSave,
+                Dom = Dom
             };
             
             context.Items.Add("DataGrid", grid);

--- a/DatatableJS/Models/GridModel.cs
+++ b/DatatableJS/Models/GridModel.cs
@@ -14,6 +14,8 @@ namespace DatatableJS
         internal bool ScrollX { get; set; }
         internal bool StateSave { get; set; }
 
+        internal string Dom { get; set; }
+
         internal List<ColumnModel> Columns { get; set; }
         internal List<FilterModel> Filters { get; set; }
         internal List<OrderModel> Orders { get; set; }


### PR DESCRIPTION
…and allow separated rendering of html & script

it can be used like this : 

` 
@{

                    var datatable =
                    Html.JS().Datatable<DashboardItemViewModel>()
                    .Name("DashboardGrid")
                    .Columns(col =>
                    {
                        col.Field(a => a.ID).Visible(false);
                        col.Field(a => a.Name);
                       ....
                        col.Command(a => a.ID, "", "", "onClick", text: "Click").Title("");
                    })
                    .Data("getPeriod")
                    .Searching(true)
                    .Callbacks(x => x.InitComplete("initComplete"))
                    .Language("https://cdn.datatables.net/plug-ins/1.13.4/i18n/fr-FR.json")
                    .URL(Url.Action("GetDashboardData", "Dashboard", new { area = "V2" }), "POST", camelCase: true)
                    .Dom("t")
                    .ServerSide(true);
                }
                    @(datatable.RenderHtml())
`


then :


`  
@section Scripts
 {
   @(datatable.RenderScript())
}
`
